### PR TITLE
Etienne chollet/alt trainer

### DIFF
--- a/cassetta/io/modules.py
+++ b/cassetta/io/modules.py
@@ -182,7 +182,7 @@ class LoadableMixin:
                 if klass is None:
                     try:
                         klass = import_qualname(
-                            sdddtate["module"],
+                            state["module"],
                             state["qualname"],
                         )
                     except Exception:

--- a/cassetta/io/modules.py
+++ b/cassetta/io/modules.py
@@ -1,19 +1,60 @@
 __all__ = [
-    'LoadableMixin',
-    'LoadableModule',
-    'LoadableModuleList',
-    'LoadableModuleDict',
-    'LoadableSequential',
-    'DynamicLoadableMixin',
-    'load_module',
-    'make_loadable',
+    "LoadableMixin",
+    "LoadableModule",
+    "LoadableModuleList",
+    "LoadableModuleDict",
+    "LoadableSequential",
+    "DynamicLoadableMixin",
+    "load_module",
+    "make_loadable",
+    "validate_loadable_module",
+    "validate_loadable_modules",
 ]
+import yaml
 import torch
+import dataclasses
 from torch import nn
+from pathlib import Path
 from typing import Union, IO
 from warnings import warn
 from inspect import signature
 from .utils import import_qualname
+
+
+def validate_loadable_module(module):
+    """
+    Validate if a single module is an instance of LoadableMixin.
+
+    Parameters
+    ----------
+    module : nn.Module
+        The module to check.
+
+    Raises
+    ------
+    TypeError
+        If the module is not an instance of LoadableMixin.
+    """
+    if not isinstance(module, LoadableMixin):
+        raise TypeError("Only Loadable modules can be added.")
+
+
+def validate_loadable_modules(modules):
+    """
+    Check if all modules in a list are instances of LoadableMixin.
+
+    Parameters
+    ----------
+    modules : iterable of nn.Module
+        The collection of modules to check.
+
+    Raises
+    ------
+    TypeError
+        If any module is not an instance of LoadableMixin.
+    """
+    for module in modules:
+        validate_loadable_module(module)
 
 
 def load_module(model_state: Union[str, IO]) -> nn.Module:
@@ -58,19 +99,20 @@ def make_loadable(klass):
     loadable_klass : type
         A `(LoadableMixin, klass)` subclass.
     """
+
     class DynamicModule(DynamicLoadableMixin, klass):
         @DynamicLoadableMixin.save_args
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
 
-    DynamicModule.__name__ = 'Loadable' + klass.__name__
-    DynamicModule.__qualname__ = 'Loadable' + klass.__name__
+    DynamicModule.__name__ = "Loadable" + klass.__name__
+    DynamicModule.__qualname__ = "Loadable" + klass.__name__
     return DynamicModule
 
 
 class LoadableMixin:
     """
-    A mixin to make a Module loadable.
+    A mixin to make a 'torch.nn.Module' loadable and savable.
 
     Example
     -------
@@ -108,7 +150,7 @@ class LoadableMixin:
     ```
     """
 
-    __version__ = '1.0'
+    __version__ = "1.0"
     """Current version of the LoadableMixin format"""
 
     @staticmethod
@@ -116,46 +158,54 @@ class LoadableMixin:
         if isinstance(obj, nn.Module):
             if not isinstance(obj, LoadableMixin):
                 raise TypeError(
-                    f'Only loadable modules (which inherit from '
-                    f'LoadableMixin) can be serialized. Type {type(obj)} '
-                    f'does not.')
+                    f"Only loadable modules (which inherit from "
+                    f"LoadableMixin) can be serialized. Type {type(obj)} "
+                    f"does not."
+                )
             return obj.serialize()
         if isinstance(obj, (list, tuple)):
             return type(obj)(map(LoadableMixin._nested_serialize, obj))
         if isinstance(obj, dict):
-            return type(obj)({
-                key: LoadableMixin._nested_serialize(value)
-                for key, value in obj.items()
-            })
+            return type(obj)(
+                {
+                    key: LoadableMixin._nested_serialize(value)
+                    for key, value in obj.items()
+                }
+            )
         return obj
 
     @staticmethod
     def _nested_unserialize(obj, *, klass=None):
         if isinstance(obj, dict):
-            if 'cassetta.LoadableState' in obj:
+            if "cassetta.LoadableState" in obj:
                 state = obj
                 if klass is None:
                     try:
                         klass = import_qualname(
-                            state['module'],
-                            state['qualname'],
+                            sdddtate["module"],
+                            state["qualname"],
                         )
                     except Exception:
                         raise ImportError(
-                            'Could not import type', state['qualname'],
-                            'from module', state['module'])
+                            "Could not import type",
+                            state["qualname"],
+                            "from module",
+                            state["module"],
+                        )
                 if not isinstance(klass, LoadableMixin):
                     klass = make_loadable(klass)
-                args = LoadableMixin._nested_unserialize(state['args'])
-                kwargs = LoadableMixin._nested_unserialize(state['kwargs'])
+                args = LoadableMixin._nested_unserialize(state["args"])
+                kwargs = LoadableMixin._nested_unserialize(state["kwargs"])
                 obj = klass(*args, **kwargs)
-                obj.load_state_dict(state['state'])
+                obj.load_state_dict(state["state"])
                 return obj
             else:
-                return type(obj)({
-                    key: LoadableMixin._nested_unserialize(value)
-                    for key, value in obj.items()
-                })
+                return type(obj)(
+                    {
+                        key: LoadableMixin._nested_unserialize(value)
+                        for key, value in obj.items()
+                    }
+                )
         if isinstance(obj, (list, tuple)):
             return type(obj)(map(LoadableMixin._nested_unserialize, obj))
         return obj
@@ -175,8 +225,9 @@ class LoadableMixin:
                 self.conv = nn.Conv3d(inp_channels, out_channels, 3)
         ```
         """
+
         def wrapper(self, *args, **kwargs):
-            if not hasattr(self, '_args'):
+            if not hasattr(self, "_args"):
                 # we only save parameters once, so that in the case where
                 # a Loadable module is subclassed, it is the parameters of
                 # the leaf class that are saved, not those passed to
@@ -184,6 +235,7 @@ class LoadableMixin:
                 self._args = cls._nested_serialize(args)
                 self._kwargs = cls._nested_serialize(kwargs)
             init(self, *args, **kwargs)
+
         return wrapper
 
     def serialize(self) -> dict:
@@ -200,12 +252,12 @@ class LoadableMixin:
         if DynamicLoadableMixin in klass.__bases__:
             klass = klass.__bases__[-1]
         return {
-            'cassetta.LoadableState': LoadableMixin.__version__,
-            'module': klass.__module__,
-            'qualname': klass.__qualname__,
-            'args': getattr(self, '_args', tuple()),
-            'kwargs': getattr(self, '_kwargs', dict()),
-            'state': self.state_dict(),
+            "cassetta.LoadableState": LoadableMixin.__version__,
+            "module": klass.__module__,
+            "qualname": klass.__qualname__,
+            "args": getattr(self, "_args", tuple()),
+            "kwargs": getattr(self, "_kwargs", dict()),
+            "state": self.state_dict(),
         }
 
     def save(self, path: Union[str, IO]) -> None:
@@ -217,11 +269,13 @@ class LoadableMixin:
         path : file_like
             Path to output module file, or opened file object.
         """
-        if not hasattr(self, '_args') and \
-                len(signature(self.__init__).parameters) > 1:
-            warn(f"Object of type {type(self).__name__} does not have "
-                 f"saved arguments. Did you decorate __init__ with "
-                 f"@save_args ?")
+        num_params = len(signature(self.__init__).parameters)
+        if not hasattr(self, "_args") and num_params > 1:
+            warn(
+                f"Object of type {type(self).__name__} does not have "
+                f"saved arguments. Did you decorate __init__ with "
+                f"@save_args ?"
+            )
         torch.save(self.serialize(), path)
 
     @classmethod
@@ -245,11 +299,91 @@ class LoadableMixin:
         return cls._nested_unserialize(loadable_state, klass=hint)
 
 
+class StateMixin:
+    """
+    A mixin to handle saving and loading the state of an object to/from a
+    dictionary or a YAML file.
+    """
+
+    def state_dict(self) -> dict:
+        """
+        Return the state of the object as a dictionary.
+
+        Returns
+        -------
+        state : dict
+            A dictionary representing the current state of the object.
+        """
+        return dataclasses.asdict(self)
+
+    def load_state_dict(self, state: Union[dict, str, Path]) -> "StateMixin":
+        """
+        Load the state of the object from a dictionary or a YAML file.
+
+        Parameters
+        ----------
+        state : dict or str or Path
+            The state dictionary or path to the YAML file containing the state.
+
+        Returns
+        -------
+        self : StateMixin
+            The instance with updated state.
+        """
+        if isinstance(state, (str, Path)):
+            with open(state, "r") as f:
+                state = yaml.load(f, Loader=yaml.Loader)  # Use full loader
+        for key, value in state.items():
+            setattr(self, key, value)
+        return self
+
+    @classmethod
+    def from_state_dict(cls, state: Union[dict, str, Path]) -> "StateMixin":
+        """
+        Create a new instance of the class from a state dictionary or YAML
+        file.
+
+        Parameters
+        ----------
+        state : dict or str or Path
+            The state dictionary or path to the YAML file containing the state.
+
+        Returns
+        -------
+        instance : StateMixin
+            A new instance of the class initialized with the given state.
+        """
+        if isinstance(state, (str, Path)):
+            with open(state, "r") as f:
+                state = yaml.safe_load(f)
+        return cls(**state)
+
+    def save_state_dict(self, path: Union[str, Path]) -> None:
+        """
+        Save the current state of the object to a YAML file.
+
+        Parameters
+        ----------
+        path : str or Path
+            The path of the YAML file to be saved.
+        """
+        state = self.state_dict()
+        with open(path, "w") as f:
+            yaml.dump(state, f)
+
+    def serialize(self):
+        """
+        Serialize the object.
+        """
+        return self.state_dict()
+
+
 class DynamicLoadableMixin(LoadableMixin):
     """
     A mixin for non-static types generated by
     [`make_loadable`](cassetta.io.modules.make_loadable)
     """
+
     pass
 
 
@@ -262,24 +396,134 @@ class LoadableModule(LoadableMixin, nn.Module):
 
 
 class LoadableSequential(LoadableMixin, nn.Sequential):
-    """A Loadable variant of [`nn.Sequential`][torch.nn.Sequential]"""
+    """A Loadable variant of nn.Sequential"""
 
-    @LoadableMixin.save_args
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, *args):
+        super().__init__(*args)
+        validate_loadable_modules(self)
+
+    def append(self, module):
+        validate_loadable_module(module)
+        super().append(module)
+
+    def extend(self, modules):
+        validate_loadable_modules(modules)
+        super().extend(modules)
+
+    def insert(self, index, module):
+        validate_loadable_module(module)
+        super().insert(index, module)
+
+    def serialize(self):
+        return {
+            "cassetta.LoadableState": LoadableMixin.__version__,
+            "module": type(self).__module__,
+            "qualname": type(self).__qualname__,
+            "modules": [module.serialize() for module in self],
+            "args": getattr(self, "_args", tuple()),
+            "kwargs": getattr(self, "_kwargs", dict()),
+            "state": self.state_dict(),
+        }
+
+    @classmethod
+    def load(cls, loadable_state):
+        if not isinstance(loadable_state, dict):
+            loadable_state = torch.load(loadable_state)
+        modules = []
+        for module_state in loadable_state["modules"]:
+            modules.append(LoadableMixin.load(module_state))
+        instance = cls(*modules)
+        return instance
+
+
+# Example:
+# class LoadableLinear(LoadableMixin, nn.Linear):
+#     @LoadableMixin.save_args
+#     def __init__(self, in_features, out_features, bias=True):
+#         super().__init__(in_features, out_features, bias)
+# model = LoadableSequential(module1, make_loadable(nn.ReLU)())
+# model.append(module2)
+# Saving:
+# model.save('loadable_sequential.pth')
+# Loading:
+# loaded_model = LoadableSequential.load('loadable_sequential.pth')
 
 
 class LoadableModuleList(LoadableMixin, nn.ModuleList):
-    """A Loadable variant of [`nn.ModuleList`][torch.nn.ModuleList]"""
+    """A Loadable variant of nn.ModuleList"""
 
-    @LoadableMixin.save_args
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, modules=None):
+        super().__init__(modules)
+        validate_loadable_modules(self)
+
+    def append(self, module):
+        validate_loadable_module(module)
+        super().append(module)
+
+    def extend(self, modules):
+        validate_loadable_modules(modules)
+        super().extend(modules)
+
+    def insert(self, index, module):
+        validate_loadable_module(module)
+        super().insert(index, module)
+
+    def serialize(self):
+        return {
+            "cassetta.LoadableState": LoadableMixin.__version__,
+            "module": type(self).__module__,
+            "qualname": type(self).__qualname__,
+            "modules": [module.serialize() for module in self],
+            "args": getattr(self, "_args", tuple()),
+            "kwargs": getattr(self, "_kwargs", dict()),
+            "state": self.state_dict(),
+        }
+
+    @classmethod
+    def load(cls, loadable_state):
+        if not isinstance(loadable_state, dict):
+            loadable_state = torch.load(loadable_state)
+        modules = []
+        for module_state in loadable_state["modules"]:
+            modules.append(LoadableMixin.load(module_state))
+        instance = cls(modules)
+        return instance
 
 
 class LoadableModuleDict(LoadableMixin, nn.ModuleDict):
-    """A Loadable variant of [`nn.ModuleDict`][torch.nn.ModuleDict]"""
+    """A Loadable variant of nn.ModuleDict"""
 
-    @LoadableMixin.save_args
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, modules=None):
+        super().__init__(modules)
+        # Ensure all modules are loadable
+        for key, module in self.items():
+            if not isinstance(module, LoadableMixin):
+                raise TypeError(f"Module '{key}' must be Loadable")
+
+    def __setitem__(self, key, module):
+        validate_loadable_module(module)
+        super().__setitem__(key, module)
+
+    def serialize(self):
+        return {
+            "cassetta.LoadableState": LoadableMixin.__version__,
+            "module": type(self).__module__,
+            "qualname": type(self).__qualname__,
+            "modules": {
+                key: module.serialize() for key, module in self.items()
+                },
+            "args": getattr(self, "_args", tuple()),
+            "kwargs": getattr(self, "_kwargs", dict()),
+            "state": self.state_dict(),
+        }
+
+    @classmethod
+    def load(cls, loadable_state):
+        if not isinstance(loadable_state, dict):
+            loadable_state = torch.load(loadable_state)
+        modules = {
+            key: LoadableMixin.load(mod_state)
+            for key, mod_state in loadable_state["modules"].items()
+        }
+        instance = cls(modules)
+        return instance

--- a/cassetta/models/segmentation.py
+++ b/cassetta/models/segmentation.py
@@ -70,10 +70,24 @@ class SegNet(LoadableMixin, nn.Sequential):
         opt_backbone : dict
             Parameters of the backbone (if backbone is not pre-instantiated)
         """
+        # Store initialization arguments for saving later
+        self._init_args = {
+            'ndim': ndim,
+            'inp_channels': inp_channels,
+            'out_channels': out_channels,
+            'kernel_size': kernel_size,
+            'activation': activation,
+            'backbone': backbone,
+            'opt_backbone': opt_backbone,
+        }
+
+        # Backbone logic
         if isinstance(backbone, str):
             backbone_kls = getattr(backbones, backbone)
             backbone = backbone_kls(ndim, **(opt_backbone or {}))
+
         activation = make_activation(activation)
+
         feat = ConvBlock(
             ndim,
             inp_channels=inp_channels,
@@ -81,6 +95,7 @@ class SegNet(LoadableMixin, nn.Sequential):
             kernel_size=kernel_size,
             activation=None,
         )
+
         pred = ConvBlock(
             ndim,
             inp_channels=backbone.out_channels,

--- a/cassetta/training/trainers.py
+++ b/cassetta/training/trainers.py
@@ -16,6 +16,7 @@ class TrainerState:
     Stores the state of the trainer, including metrics, losses, epoch, and
     step.
     """
+
     all_losses: Dict[str, Any] = None
     all_metrics: Dict[str, Any] = None
     current_losses: Dict[str, Any] = None
@@ -57,7 +58,9 @@ class Trainer(nn.Module):
         self.optimizers = {}
         self.trainer_state = TrainerState()
 
-    def register_model(self, name, model: nn.Module, optimizer: torch.optim.Optimizer = None):
+    def register_model(
+        self, name, model: nn.Module, optimizer: torch.optim.Optimizer = None
+    ):
         """
         Register a model to the Trainer, along with its optimizer.
         """
@@ -67,14 +70,24 @@ class Trainer(nn.Module):
 
     def save(self, file_path):
         """
-        Save the Trainer state, including all models, optimizers, and trainer state.
+        Save the Trainer state, including all models, optimizers, and trainer
+        state.
         """
         checkpoint = {
-            'models': {name: model.state_dict() for name, model in self.models.items()},
-            'optimizers': {name: optimizer.state_dict() for name, optimizer in self.optimizers.items()},
-            'trainer_state': self.trainer_state.__dict__,
-            'model_classes': {name: model.__class__ for name, model in self.models.items()},
-            'model_init_args': {name: model._init_args for name, model in self.models.items()}  # Save model initialization arguments
+            "models": {
+                name: model.state_dict() for name, model in self.models.items()
+                },
+            "optimizers": {
+                name: optimizer.state_dict()
+                for name, optimizer in self.optimizers.items()
+            },
+            "trainer_state": self.trainer_state.__dict__,
+            "model_classes": {
+                name: model.__class__ for name, model in self.models.items()
+            },
+            "model_init_args": {
+                name: model._init_args for name, model in self.models.items()
+            },  # Save model initialization arguments
         }
         torch.save(checkpoint, file_path)
         print(f"Trainer state saved to {file_path}")
@@ -90,35 +103,37 @@ class Trainer(nn.Module):
         checkpoint = torch.load(file_path)
 
         # Re-create models from saved classes and their init args
-        for name, model_class in checkpoint['model_classes'].items():
+        for name, model_class in checkpoint["model_classes"].items():
             # Load model initialization arguments
-            init_args = checkpoint['model_init_args'][name]
+            init_args = checkpoint["model_init_args"][name]
 
             if name not in self.models:
                 # Dynamically create the model using the saved init args
                 model = model_class(**init_args)
-                model.load_state_dict(checkpoint['models'][name])
+                model.load_state_dict(checkpoint["models"][name])
                 self.models[name] = model
             else:
-                self.models[name].load_state_dict(checkpoint['models'][name])
+                self.models[name].load_state_dict(checkpoint["models"][name])
 
             if name not in self.optimizers:
                 # Adjust optimizer as needed
                 optimizer = torch.optim.Adam(self.models[name].parameters())
-                optimizer.load_state_dict(checkpoint['optimizers'][name])
+                optimizer.load_state_dict(checkpoint["optimizers"][name])
                 self.optimizers[name] = optimizer
             else:
                 self.optimizers[name].load_state_dict(
-                    checkpoint['optimizers'][name])
+                    checkpoint["optimizers"][name]
+                    )
 
         # Restore trainer state
-        self.trainer_state.__dict__.update(checkpoint['trainer_state'])
+        self.trainer_state.__dict__.update(checkpoint["trainer_state"])
         print(f"Trainer state loaded from {file_path}")
         return self
 
+
 class BasicTrainer(Trainer):
 
-    @Trainer.save_args
+    # @Trainer.save_args
     def __init__(
         self,
         model: Union[str, nn.Module],

--- a/cassetta/training/trainers.py
+++ b/cassetta/training/trainers.py
@@ -1,91 +1,120 @@
+import os
 import torch
 from torch import nn
 from torch import optim as torch_optim
 from torch.optim import Optimizer
 from torch.utils.data import Dataset, DataLoader
-from typing import Union, Optional
+from typing import Union, Optional, Dict, Any
 from dataclasses import dataclass, asdict
-from cassetta.io.modules import LoadableModule
 from cassetta.io.utils import import_fullname, import_qualname
 from cassetta import models, losses
 
 
 @dataclass
 class TrainerState:
-    all_losses: dict = {}
-    all_metrics: dict = {}
-    current_losses: dict = {}
-    current_metrics: dict = {}
+    """
+    Stores the state of the trainer, including metrics, losses, epoch, and
+    step.
+    """
+    all_losses: Dict[str, Any] = None
+    all_metrics: Dict[str, Any] = None
+    current_losses: Dict[str, Any] = None
+    current_metrics: Dict[str, Any] = None
     current_epoch: int = 0
     current_step: int = 0
 
-    def serialize(self) -> dict:
+    def serialize(self) -> Dict[str, Any]:
+        """
+        Serializes the trainer state.
+        """
         return asdict(self)
 
-    def save(self, path):
+    def save(self, path: str) -> None:
+        """
+        Saves serialized trainer state to a file.
+        """
         torch.save(self.serialize(), path)
 
     @classmethod
-    def load(cls, state):
+    def load(cls, state: Union[str, Dict[str, Any]]) -> "TrainerState":
+        """
+        Loads the trainer state from a file or dict.
+        """
         if not isinstance(state, dict):
             state = torch.load(state)
         return cls(**state)
 
 
-class Trainer(LoadableModule):
+class Trainer(nn.Module):
+    """
+    Base class for training models with serialization and state loading.
+    Handles registering models, saving entire state to a file, and loading it.
+    """
 
-    @LoadableModule.save_args
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.models = nn.ModuleDict()
         self.optimizers = {}
         self.trainer_state = TrainerState()
 
-    def serialize(self) -> dict:
-        state = super().serialize()
-        state.update({
-            'optimizers': [optim.state_dict() for optim in self.optimizers],
-            'trainer_state': self.trainer_state.serialize(),
-        })
-        return state
-
-    def load(cls, state):
-        if not isinstance(state, dict):
-            state = torch.load(state)
-        obj = super().load(state)
-        for name, optim in obj.optimizers.items():
-            optim.load_state_dict(state['optimizers'][name])
-        obj.trainer_state = TrainerState.load(state['trainer_state'])
-        return obj
-
-    def register_model(self, name, model: nn.Module):
+    def register_model(self, name, model: nn.Module, optimizer: torch.optim.Optimizer = None):
+        """
+        Register a model to the Trainer, along with its optimizer.
+        """
         self.models[name] = model
+        if optimizer:
+            self.optimizers[name] = optimizer
 
-    def register_optimizer(self, name, optim: Optimizer):
-        self.optimizers[name] = optim
+    def save(self, file_path):
+        """
+        Save the Trainer state, including all models, optimizers, and trainer state.
+        """
+        checkpoint = {
+            'models': {name: model.state_dict() for name, model in self.models.items()},
+            'optimizers': {name: optimizer.state_dict() for name, optimizer in self.optimizers.items()},
+            'trainer_state': self.trainer_state.__dict__,
+            'model_classes': {name: model.__class__ for name, model in self.models.items()},
+            'model_init_args': {name: model._init_args for name, model in self.models.items()}  # Save model initialization arguments
+        }
+        torch.save(checkpoint, file_path)
+        print(f"Trainer state saved to {file_path}")
 
-    def train_step(self, minibatch):
-        raise NotImplementedError
+    def load(self, file_path):
+        """
+        Load the Trainer state from a file, restoring models, optimizers,
+        and trainer state.
+        """
+        if not os.path.exists(file_path):
+            raise FileNotFoundError(f"No saved trainer found at {file_path}")
 
-    def eval_step(self, minibatch):
-        raise NotImplementedError
+        checkpoint = torch.load(file_path)
 
-    def log_loss(self, name, value):
-        raise NotImplementedError
+        # Re-create models from saved classes and their init args
+        for name, model_class in checkpoint['model_classes'].items():
+            # Load model initialization arguments
+            init_args = checkpoint['model_init_args'][name]
 
-    def log_metric(self, name, value):
-        raise NotImplementedError
+            if name not in self.models:
+                # Dynamically create the model using the saved init args
+                model = model_class(**init_args)
+                model.load_state_dict(checkpoint['models'][name])
+                self.models[name] = model
+            else:
+                self.models[name].load_state_dict(checkpoint['models'][name])
 
-    def train_epoch(self):
-        for minibatch in self.iter_trainset():
-            self.train_step(minibatch)
-            self.update_progress_train()
+            if name not in self.optimizers:
+                # Adjust optimizer as needed
+                optimizer = torch.optim.Adam(self.models[name].parameters())
+                optimizer.load_state_dict(checkpoint['optimizers'][name])
+                self.optimizers[name] = optimizer
+            else:
+                self.optimizers[name].load_state_dict(
+                    checkpoint['optimizers'][name])
 
-    def eval_epoch(self):
-        for minibatch in self.iter_evalset():
-            self.eval_step(minibatch)
-            self.update_progress_eval()
-
+        # Restore trainer state
+        self.trainer_state.__dict__.update(checkpoint['trainer_state'])
+        print(f"Trainer state loaded from {file_path}")
+        return self
 
 class BasicTrainer(Trainer):
 
@@ -108,15 +137,15 @@ class BasicTrainer(Trainer):
         super().__init__()
 
         # instantiate and register model
-        self.models['model'] = models.make_model(model, **(opt_model or {}))
+        self.models["model"] = models.make_model(model, **(opt_model or {}))
 
         # instantiate and register loss
-        self.models['loss'] = losses.make_loss(loss, **(opt_loss or {}))
+        self.models["loss"] = losses.make_loss(loss, **(opt_loss or {}))
 
         # instantiate and register optim
         if isinstance(optim, str):
-            if '.' not in optim:
+            if "." not in optim:
                 optim = import_qualname(torch_optim, optim)
             else:
                 optim = import_fullname(optim)
-            self.optimizers['model'] = (optim, lr)
+            self.optimizers["model"] = (optim, lr)

--- a/cassetta/training/trainers.py
+++ b/cassetta/training/trainers.py
@@ -8,6 +8,7 @@ from typing import Union, Optional, Dict, Any
 from dataclasses import dataclass, asdict
 from cassetta.io.utils import import_fullname, import_qualname
 from cassetta import models, losses
+from cassetta.io.modules import LoadableModuleDict
 
 
 @dataclass
@@ -54,7 +55,7 @@ class Trainer(nn.Module):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.models = nn.ModuleDict()
+        self.models = LoadableModuleDict()
         self.optimizers = {}
         self.trainer_state = TrainerState()
 

--- a/cassetta/training/trainers.py
+++ b/cassetta/training/trainers.py
@@ -1,0 +1,122 @@
+import torch
+from torch import nn
+from torch import optim as torch_optim
+from torch.optim import Optimizer
+from torch.utils.data import Dataset, DataLoader
+from typing import Union, Optional
+from dataclasses import dataclass, asdict
+from cassetta.io.modules import LoadableModule
+from cassetta.io.utils import import_fullname, import_qualname
+from cassetta import models, losses
+
+
+@dataclass
+class TrainerState:
+    all_losses: dict = {}
+    all_metrics: dict = {}
+    current_losses: dict = {}
+    current_metrics: dict = {}
+    current_epoch: int = 0
+    current_step: int = 0
+
+    def serialize(self) -> dict:
+        return asdict(self)
+
+    def save(self, path):
+        torch.save(self.serialize(), path)
+
+    @classmethod
+    def load(cls, state):
+        if not isinstance(state, dict):
+            state = torch.load(state)
+        return cls(**state)
+
+
+class Trainer(LoadableModule):
+
+    @LoadableModule.save_args
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.models = nn.ModuleDict()
+        self.optimizers = {}
+        self.trainer_state = TrainerState()
+
+    def serialize(self) -> dict:
+        state = super().serialize()
+        state.update({
+            'optimizers': [optim.state_dict() for optim in self.optimizers],
+            'trainer_state': self.trainer_state.serialize(),
+        })
+        return state
+
+    def load(cls, state):
+        if not isinstance(state, dict):
+            state = torch.load(state)
+        obj = super().load(state)
+        for name, optim in obj.optimizers.items():
+            optim.load_state_dict(state['optimizers'][name])
+        obj.trainer_state = TrainerState.load(state['trainer_state'])
+        return obj
+
+    def register_model(self, name, model: nn.Module):
+        self.models[name] = model
+
+    def register_optimizer(self, name, optim: Optimizer):
+        self.optimizers[name] = optim
+
+    def train_step(self, minibatch):
+        raise NotImplementedError
+
+    def eval_step(self, minibatch):
+        raise NotImplementedError
+
+    def log_loss(self, name, value):
+        raise NotImplementedError
+
+    def log_metric(self, name, value):
+        raise NotImplementedError
+
+    def train_epoch(self):
+        for minibatch in self.iter_trainset():
+            self.train_step(minibatch)
+            self.update_progress_train()
+
+    def eval_epoch(self):
+        for minibatch in self.iter_evalset():
+            self.eval_step(minibatch)
+            self.update_progress_eval()
+
+
+class BasicTrainer(Trainer):
+
+    @Trainer.save_args
+    def __init__(
+        self,
+        model: Union[str, nn.Module],
+        loss: Union[str, nn.Module],
+        optim: Union[str, Optimizer],
+        trainset: Union[Dataset, DataLoader],
+        evalset: Optional[Union[Dataset, DataLoader]] = None,
+        nb_epochs: int = None,
+        nb_steps: int = None,
+        early_stopping: float = 0,
+        lr=1e-4,
+        *,
+        opt_model: dict = None,
+        opt_loss: dict = None,
+    ):
+        super().__init__()
+
+        # instantiate and register model
+        self.models['model'] = models.make_model(model, **(opt_model or {}))
+
+        # instantiate and register loss
+        self.models['loss'] = losses.make_loss(loss, **(opt_loss or {}))
+
+        # instantiate and register optim
+        if isinstance(optim, str):
+            if '.' not in optim:
+                optim = import_qualname(torch_optim, optim)
+            else:
+                optim = import_fullname(optim)
+            self.optimizers['model'] = (optim, lr)


### PR DESCRIPTION
1. Change the way the Loadable {Sequential, ModuleList, ModuleDict} are saved by removing `@saveargs` and adding custom `serialize()` and `load()` methods. 
2. Restrict `Loadable` {`Sequential`, `ModuleList`, `ModuleDict`} to *only* contain loadable modules. Modules are checked when class is instantiated and when append, extend, and insert methods are called.
3. Update `Trainer` to only accept loadable modules for models attribute.
4. Slightly update `SegNet` (temporary fix) for better model saving and loading with `Trainer`.
